### PR TITLE
Add What Broke Today to Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ Challenge your friends in MULTIPLAYER mode!
  * [BanOnExit](https://github.com/BotMaven/BanOnExit) - Automatically ban users who join and leave your Telegram groups or channels within a configurable time frame
  * [telegram-owl](https://github.com/beeyev/telegram-owl) - Send messages and files to Telegram chats and channels, directly from terminal. Lightweight tool written in Go.
  * [telegram-finder](https://www.telegram-finder.io) - Find Telegram users from phone, email, or LinkedIn URL, via web app or API.
+ * [What Broke Today](https://whatbroke.today) - AI-powered outage aggregator with real-time Telegram alerts for 100+ cloud services (AWS, Azure, GCP, GitHub, Cloudflare and more).
  * [telepipe](https://github.com/Linuxmaster14/telepipe) – Lightweight Bash utility for piping command output to Telegram chats. Automatically switches between message and file modes based on content length.
 
 ## Themes

--- a/README.md
+++ b/README.md
@@ -201,8 +201,8 @@ Challenge your friends in MULTIPLAYER mode!
  * [BanOnExit](https://github.com/BotMaven/BanOnExit) - Automatically ban users who join and leave your Telegram groups or channels within a configurable time frame
  * [telegram-owl](https://github.com/beeyev/telegram-owl) - Send messages and files to Telegram chats and channels, directly from terminal. Lightweight tool written in Go.
  * [telegram-finder](https://www.telegram-finder.io) - Find Telegram users from phone, email, or LinkedIn URL, via web app or API.
- * [What Broke Today](https://whatbroke.today) - AI-powered outage aggregator with real-time Telegram alerts for 100+ cloud services (AWS, Azure, GCP, GitHub, Cloudflare and more).
  * [telepipe](https://github.com/Linuxmaster14/telepipe) – Lightweight Bash utility for piping command output to Telegram chats. Automatically switches between message and file modes based on content length.
+ * [What Broke Today](https://whatbroke.today) – Aggregates status pages from 100+ cloud services. Telegram alerts, RSS feed, JSON API.
 
 ## Themes
 


### PR DESCRIPTION
## Summary

Adding [What Broke Today](https://whatbroke.today/) to the Tools section.

**What Broke Today** is an AI-powered outage aggregator with a Telegram channel that:
- Monitors 100+ cloud services (AWS, Azure, GCP, GitHub, Cloudflare, Slack, Stripe, etc.)
- Sends real-time Telegram alerts when outages are detected
- Uses AI to filter and summarize service outages

**Website**: https://whatbroke.today
**Telegram Channel**: https://t.me/whatbroketoday