### PR TITLE
Add GitHub Trendz channel (t.me/github_trendz) to Channels section

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,8 @@ Challenge your friends in MULTIPLAYER mode!
 * [CatOps](https://t.me/catops) - News and notes about DevOps, SRE, and more.
 * [Kubernative](https://t.me/kubernative) - News, tools, and articles about Kubernetes and other cloud native projects for DevOps & SRE engineers.
 * [Raycast New Extensions](https://t.me/raycast_new_extensions) - Automated feed with recently added extensions from the Raycast Store
+* [GitHub Trendz](https://t.me/github_trendz) – Daily GitHub Trending repositories. Projects gaining stars today — tools, libraries, and ideas worth exploring.
+
 
 ## Bot Stores
 


### PR DESCRIPTION
This PR adds the Telegram channel "GitHub Trendz" to the Channels section of README.

Channel: https://t.me/github_trendz
Description: Daily GitHub Trending repositories. Projects gaining stars today — tools, libraries, and ideas worth exploring.

Why: The channel posts daily GitHub trending repositories and can be useful for developers who want to discover new projects quickly.

Notes:
- Public channel.
- Content is automated daily-trending posts (not spam).
- If you prefer a different wording or placement, tell me and I'll update the PR.