### PR TITLE
Add OpenClaw - multi-channel AI assistant with Telegram support

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Join our supergroup on Telegram: [![@awesometelegram](https://img.shields.io/bad
 * [@ximanager_bot](https://t.me/ximanager_bot) – 🀄️ An AI-powered Telegram bot styled as Xi’s personal assistant. The great leader’s personal aide, ready to answer the questions of people.
 * [@TagEveryone_TheBot](https://t.me/TagEveryone_TheBot) –  is an [Open Source](https://github.com/Matt0550/TagEveryoneTelegramBot) Telegram bot that lets users mention all group members with /everyone﻿ or @all﻿, similar to Discord mentions. Members opt in via /in﻿, but new users are now added automatically.
 * [@KillerBgBot](https://t.me/KillerBgBot) – Background Removal Bot with Bulk Upload Support and No Loss of Quality.
-* [OpenClaw](https://github.com/openclaw/openclaw) – [Open Source](https://github.com/openclaw/openclaw) Self-hosted AI assistant that connects Claude to Telegram (and 7 other channels) from a single deployment. Supports hooks, plugins, and tools. ([Setup guide](https://clawdbot.blog/channels/telegram/))
+* [OpenClaw](https://github.com/openclaw/openclaw) – Self-hosted AI assistant that connects Claude to Telegram (and 7 other channels) from a single deployment. Supports hooks, plugins, and tools. Telegram setup: https://clawdbot.blog/channels/telegram/
 
 ### Inline Bots
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Join our supergroup on Telegram: [![@awesometelegram](https://img.shields.io/bad
 * [@ximanager_bot](https://t.me/ximanager_bot) – 🀄️ An AI-powered Telegram bot styled as Xi’s personal assistant. The great leader’s personal aide, ready to answer the questions of people.
 * [@TagEveryone_TheBot](https://t.me/TagEveryone_TheBot) –  is an [Open Source](https://github.com/Matt0550/TagEveryoneTelegramBot) Telegram bot that lets users mention all group members with /everyone﻿ or @all﻿, similar to Discord mentions. Members opt in via /in﻿, but new users are now added automatically.
 * [@KillerBgBot](https://t.me/KillerBgBot) – Background Removal Bot with Bulk Upload Support and No Loss of Quality.
+* [OpenClaw](https://github.com/openclaw/openclaw) – [Open Source](https://github.com/openclaw/openclaw) Self-hosted AI assistant that connects Claude to Telegram (and 7 other channels) from a single deployment. Supports hooks, plugins, and tools. ([Setup guide](https://clawdbot.blog/channels/telegram/))
 
 ### Inline Bots
 


### PR DESCRIPTION
Adding [OpenClaw](https://github.com/openclaw/openclaw) to the Bots section.

OpenClaw is an open-source, self-hosted AI assistant that connects Claude to Telegram and seven other messaging channels (WhatsApp, Discord, Slack, iMessage, SMS, Email, Signal) from a single deployment. It features a Telegram channel adapter with support for text, voice, images, and group chats.

- **GitHub**: https://github.com/openclaw/openclaw (190k+ stars, MIT licensed)
- **Telegram setup**: https://clawdbot.blog/channels/telegram/
- **Language**: TypeScript