### PR TITLE
Add Signal AI Digest — AI-curated daily news bot for Telegram

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ Join our supergroup on Telegram: [![@awesometelegram](https://img.shields.io/bad
 
 * [@Stickers](https://telegram.me/Stickers) – Official Telegram stickers bot.
 * [@Forbesbot](https://telegram.me/Forbesbot) – Official Forbes business news bot.
-* [@SignalDigest_Bot](https://t.me/SignalDigest_Bot) – AI-curated personalized daily news digest. Delivers 3-10 top stories from 25+ sources (Reuters, Bloomberg, TechCrunch, FT, CoinTelegraph, Foreign Policy) matched to your topics every morning. Free tier available.
 * [@TechCrunchBot](https://telegram.me/TechCrunchBot) – Official TechCrunch technology news bot.
 * [@StoreBot](https://telegram.me/StoreBot) – Telegram store bot.
 * [@weatherman_bot](https://telegram.me/weatherman_bot) - Bot shows weather in your city.
@@ -52,6 +51,8 @@ Join our supergroup on Telegram: [![@awesometelegram](https://img.shields.io/bad
 * [@ximanager_bot](https://t.me/ximanager_bot) – 🀄️ An AI-powered Telegram bot styled as Xi’s personal assistant. The great leader’s personal aide, ready to answer the questions of people.
 * [@TagEveryone_TheBot](https://t.me/TagEveryone_TheBot) –  is an [Open Source](https://github.com/Matt0550/TagEveryoneTelegramBot) Telegram bot that lets users mention all group members with /everyone﻿ or @all﻿, similar to Discord mentions. Members opt in via /in﻿, but new users are now added automatically.
 * [@KillerBgBot](https://t.me/KillerBgBot) – Background Removal Bot with Bulk Upload Support and No Loss of Quality.
+
+* [@SignalDigest_Bot](https://t.me/SignalDigest_Bot) - AI-curated daily news digest for Telegram. Pick your topics (AI, tech, markets, crypto, world news) and receive 5–10 curated stories with source citations every day. Free tier: 3 stories/day. Paid: $5/month.
 
 ### Inline Bots
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Join our supergroup on Telegram: [![@awesometelegram](https://img.shields.io/bad
 
 * [@Stickers](https://telegram.me/Stickers) – Official Telegram stickers bot.
 * [@Forbesbot](https://telegram.me/Forbesbot) – Official Forbes business news bot.
+* [@SignalDigest_Bot](https://t.me/SignalDigest_Bot) – AI-curated personalized daily news digest. Delivers 3-10 top stories from 25+ sources (Reuters, Bloomberg, TechCrunch, FT, CoinTelegraph, Foreign Policy) matched to your topics every morning. Free tier available.
 * [@TechCrunchBot](https://telegram.me/TechCrunchBot) – Official TechCrunch technology news bot.
 * [@StoreBot](https://telegram.me/StoreBot) – Telegram store bot.
 * [@weatherman_bot](https://telegram.me/weatherman_bot) - Bot shows weather in your city.


### PR DESCRIPTION
Adding **[@SignalDigest_Bot](https://t.me/SignalDigest_Bot)** to the Bots section.

**What it does:** Signal AI Digest is a Telegram bot that delivers AI-curated daily news personalized to each user's interests.

- Users pick topics (AI, tech, business, markets, crypto, world news, etc.)
- Bot aggregates from 172 RSS sources and scores for relevance
- GPT-4o-mini writes clean 2–3 sentence summaries with source citations
- Free tier: 3 stories/day | Paid: 10 stories/day ($5/month)
- Landing page: https://signaldigest.ai

Fits naturally alongside @Forbesbot and @TechCrunchBot as a news-focused Telegram bot, with the added value of full personalization and AI summarization.