### PR TITLE
Add OpenPaw to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ Challenge your friends in MULTIPLAYER mode!
  * [telegram-finder](https://www.telegram-finder.io) - Find Telegram users from phone, email, or LinkedIn URL, via web app or API.
  * [Telegram Media Downloader](https://github.com/rfsbraz/telegram-downloader) – Self-hosted daemon that automatically downloads media from Telegram channels, groups, and forum topics.
  * [telepipe](https://github.com/Linuxmaster14/telepipe) – Lightweight Bash utility for piping command output to Telegram chats. Automatically switches between message and file modes based on content length.
+ * [OpenPaw](https://github.com/daxaur/openpaw) – Open-source CLI tool (`npx pawmode`) with a built-in Telegram bridge to chat with Claude from your phone. Includes 38 skills covering email, calendar, Spotify, smart home, GitHub, Slack and more.
 
 ## Themes
 


### PR DESCRIPTION
Hi! Adding [OpenPaw](https://github.com/daxaur/openpaw) to the Tools section.

It's an open-source CLI tool (`npx pawmode`) that includes a built-in Telegram bridge, so you can chat with Claude directly from your phone. It also ships with 38 skills — email, calendar, Spotify, smart home, GitHub, Slack, and more. MIT licensed.

- GitHub: https://github.com/daxaur/openpaw
- npm: https://www.npmjs.com/package/pawmode