### PR TITLE
Add OpenClaw Easy

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ Challenge your friends in MULTIPLAYER mode!
  * [telegram-finder](https://www.telegram-finder.io) - Find Telegram users from phone, email, or LinkedIn URL, via web app or API.
  * [Telegram Media Downloader](https://github.com/rfsbraz/telegram-downloader) – Self-hosted daemon that automatically downloads media from Telegram channels, groups, and forum topics.
  * [telepipe](https://github.com/Linuxmaster14/telepipe) – Lightweight Bash utility for piping command output to Telegram chats. Automatically switches between message and file modes based on content length.
+ * [OpenClaw Easy](https://openclaw-easy.com) – Free desktop app that connects AI/LLMs (ChatGPT, Claude, Ollama) to Telegram, WhatsApp, Slack, and Discord.
 
 ## Themes
 


### PR DESCRIPTION
Add [OpenClaw Easy](https://openclaw-easy.com) to the Tools section.

OpenClaw Easy is a free desktop app that connects AI/LLMs (ChatGPT, Claude, Ollama) to Telegram, WhatsApp, Slack, and Discord.

Website: https://openclaw-easy.com