### PR TITLE
Add Telegram Delay Channel Cloner to Bots

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Join our supergroup on Telegram: [![@awesometelegram](https://img.shields.io/bad
 * [@ximanager_bot](https://t.me/ximanager_bot) – 🀄️ An AI-powered Telegram bot styled as Xi’s personal assistant. The great leader’s personal aide, ready to answer the questions of people.
 * [@TagEveryone_TheBot](https://t.me/TagEveryone_TheBot) –  is an [Open Source](https://github.com/Matt0550/TagEveryoneTelegramBot) Telegram bot that lets users mention all group members with /everyone﻿ or @all﻿, similar to Discord mentions. Members opt in via /in﻿, but new users are now added automatically.
 * [@KillerBgBot](https://t.me/KillerBgBot) – Background Removal Bot with Bulk Upload Support and No Loss of Quality.
+* [Telegram Delay Channel Cloner](https://github.com/GeiserX/telegram-delay-channel-cloner) – Bot that relays messages between Telegram channels with configurable delay and batch processing.
 
 ### Inline Bots
 


### PR DESCRIPTION
## Summary
- Adds [Telegram Delay Channel Cloner](https://github.com/GeiserX/telegram-delay-channel-cloner) to the Bots section.
- A bot that relays messages between Telegram channels with configurable delay and batch processing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)