### PR TITLE
Add Paperless Telegram Bot to Bots

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Join our supergroup on Telegram: [![@awesometelegram](https://img.shields.io/bad
 * [@ximanager_bot](https://t.me/ximanager_bot) – 🀄️ An AI-powered Telegram bot styled as Xi’s personal assistant. The great leader’s personal aide, ready to answer the questions of people.
 * [@TagEveryone_TheBot](https://t.me/TagEveryone_TheBot) –  is an [Open Source](https://github.com/Matt0550/TagEveryoneTelegramBot) Telegram bot that lets users mention all group members with /everyone﻿ or @all﻿, similar to Discord mentions. Members opt in via /in﻿, but new users are now added automatically.
 * [@KillerBgBot](https://t.me/KillerBgBot) – Background Removal Bot with Bulk Upload Support and No Loss of Quality.
+* [Paperless Telegram Bot](https://github.com/GeiserX/paperless-telegram-bot) – Manage Paperless-NGX documents through Telegram with upload, search, tagging, and inbox review workflows.
 
 ### Inline Bots
 


### PR DESCRIPTION
## Summary
- Adds [Paperless Telegram Bot](https://github.com/GeiserX/paperless-telegram-bot) to the Bots section.
- A bot to manage Paperless-NGX documents through Telegram with upload, search, tagging, and inbox review workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)