### PR TITLE
Add Jellyfin Telegram Channel Sync to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ Challenge your friends in MULTIPLAYER mode!
  * [telegram-finder](https://www.telegram-finder.io) - Find Telegram users from phone, email, or LinkedIn URL, via web app or API.
  * [Telegram Media Downloader](https://github.com/rfsbraz/telegram-downloader) – Self-hosted daemon that automatically downloads media from Telegram channels, groups, and forum topics.
  * [telepipe](https://github.com/Linuxmaster14/telepipe) – Lightweight Bash utility for piping command output to Telegram chats. Automatically switches between message and file modes based on content length.
+ * [Jellyfin Telegram Channel Sync](https://github.com/GeiserX/jellyfin-telegram-channel-sync) - Sync Jellyfin media server user access with Telegram channel membership.
 
 ## Themes
 


### PR DESCRIPTION
## Summary
- Adds [Jellyfin Telegram Channel Sync](https://github.com/GeiserX/jellyfin-telegram-channel-sync) to the Tools section.
- A tool to sync Jellyfin media server user access with Telegram channel membership.

🤖 Generated with [Claude Code](https://claude.com/claude-code)