### PR TITLE
Add Telegram-Archive to Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ Challenge your friends in MULTIPLAYER mode!
  * [BanOnExit](https://github.com/BotMaven/BanOnExit) - Automatically ban users who join and leave your Telegram groups or channels within a configurable time frame
  * [telegram-owl](https://github.com/beeyev/telegram-owl) - Send messages and files to Telegram chats and channels, directly from terminal. Lightweight tool written in Go.
  * [telegram-finder](https://www.telegram-finder.io) - Find Telegram users from phone, email, or LinkedIn URL, via web app or API.
+ * [Telegram-Archive](https://github.com/GeiserX/Telegram-Archive) – Docker-based tool for archiving Telegram channels and groups with full media support, incremental backups, and a local web viewer.
  * [Telegram Media Downloader](https://github.com/rfsbraz/telegram-downloader) – Self-hosted daemon that automatically downloads media from Telegram channels, groups, and forum topics.
  * [telepipe](https://github.com/Linuxmaster14/telepipe) – Lightweight Bash utility for piping command output to Telegram chats. Automatically switches between message and file modes based on content length.
 


### PR DESCRIPTION
## Summary

- Adds [Telegram-Archive](https://github.com/GeiserX/Telegram-Archive) to the **Tools** section
- Docker-based tool for archiving Telegram channels and groups with full media support (messages, photos, videos, documents), incremental backups, and a local web viewer
- Written in Python, licensed under GPL-3.0
- 87 stars on GitHub

## Details

Telegram-Archive archives Telegram channels/groups to local storage with:
- Automated, incremental backups
- Full media download support (photos, videos, documents, etc.)
- Built-in web viewer that mirrors the Telegram UI
- Docker-ready deployment
- PostgreSQL/SQLite support

The entry is placed alphabetically within the Tools section.