### PR TITLE
Add AskePub to Bots section

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Join our supergroup on Telegram: [![@awesometelegram](https://img.shields.io/bad
 * [@ximanager_bot](https://t.me/ximanager_bot) – 🀄️ An AI-powered Telegram bot styled as Xi’s personal assistant. The great leader’s personal aide, ready to answer the questions of people.
 * [@TagEveryone_TheBot](https://t.me/TagEveryone_TheBot) –  is an [Open Source](https://github.com/Matt0550/TagEveryoneTelegramBot) Telegram bot that lets users mention all group members with /everyone﻿ or @all﻿, similar to Discord mentions. Members opt in via /in﻿, but new users are now added automatically.
 * [@KillerBgBot](https://t.me/KillerBgBot) – Background Removal Bot with Bulk Upload Support and No Loss of Quality.
+* [AskePub](https://github.com/GeiserX/AskePub) – Open-source bot that uses GPT-4o to generate AI study notes from ePub books.
 
 ### Inline Bots
 


### PR DESCRIPTION
## Summary
- Adds [AskePub](https://github.com/GeiserX/AskePub) to the Bots section
- AskePub is a self-hosted Telegram bot that generates AI study notes from ePub books using GPT-4o
- Open source (MIT), Dockerized, Python