### PR TITLE
Add Yazoul Security channel to Security section

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ Challenge your friends in MULTIPLAYER mode!
 
 ### Cybersecurity
 
-- [@yazoul](https://t.me/yazoul) - Automated CVE advisories, data breach alerts, dark web intel, and correlated threat news. Updated daily.
+* [@yazoul](https://t.me/yazoul) – Automated CVE advisories, data breach alerts, dark web intel, and correlated threat news. Updated daily.
 
 ### AI Security
 

--- a/README.md
+++ b/README.md
@@ -283,10 +283,6 @@ Challenge your friends in MULTIPLAYER mode!
 
 ## Security
 
-### Cybersecurity
-
-* [@yazoul](https://t.me/yazoul) – Automated CVE advisories, data breach alerts, dark web intel, and correlated threat news. Updated daily.
-
 ### AI Security
 
 * [PWN AI](https://t.me/pwnai) – (RU) Practical AI Security and MLSecOps: how to apply AI in security engineering, how AI breaks, and how to defend it. Strong focus on LLM security, agents, guardrails, real-world threats
@@ -304,6 +300,10 @@ Challenge your friends in MULTIPLAYER mode!
 * [AISecurilka](https://t.me/aisecurilka) – (RU) Niche AI security channel. Emerging space for short notes, links and experiments around AI/LLM security (description to be refined as it grows).
 * [AGI Security](https://t.me/agisec) – (EN) “Artificial General Intelligence Security” — discussions and links around long-term AGI security, safety and existential-risk-flavoured topics.
 * [paranoAISecure](https://t.me/paranoAISecure) – (RU/EN) Experimental channel on “healthy paranoia” for AI systems: threat modeling, secure design patterns, operational practices for AI security (early-stage, description to be clarified).
+
+### Cybersecurity
+
+* [@yazoul](https://t.me/yazoul) – Automated CVE advisories, data breach alerts, dark web intel, and correlated threat news. Updated daily.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -283,6 +283,10 @@ Challenge your friends in MULTIPLAYER mode!
 
 ## Security
 
+### Cybersecurity
+
+- [@yazoul](https://t.me/yazoul) - Automated CVE advisories, data breach alerts, dark web intel, and correlated threat news. Updated daily.
+
 ### AI Security
 
 * [PWN AI](https://t.me/pwnai) – (RU) Practical AI Security and MLSecOps: how to apply AI in security engineering, how AI breaks, and how to defend it. Strong focus on LLM security, agents, guardrails, real-world threats


### PR DESCRIPTION
Description:

Added [@yazoul](https://t.me/yazoul) to the Security section - a free, automated cybersecurity intelligence channel that posts daily CVE advisories, data breach alerts, dark web threat intel, and correlated security news from 10+ feeds. All content is open and community-driven with no ads or paywalls.