### PR TITLE
Add BotVa to Bots section

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Join our supergroup on Telegram: [![@awesometelegram](https://img.shields.io/bad
 * [@ximanager_bot](https://t.me/ximanager_bot) – 🀄️ An AI-powered Telegram bot styled as Xi’s personal assistant. The great leader’s personal aide, ready to answer the questions of people.
 * [@TagEveryone_TheBot](https://t.me/TagEveryone_TheBot) –  is an [Open Source](https://github.com/Matt0550/TagEveryoneTelegramBot) Telegram bot that lets users mention all group members with /everyone﻿ or @all﻿, similar to Discord mentions. Members opt in via /in﻿, but new users are now added automatically.
 * [@KillerBgBot](https://t.me/KillerBgBot) – Background Removal Bot with Bulk Upload Support and No Loss of Quality.
+* [BotVa](https://github.com/cohe4ko/BotVa) - [Open Source](https://github.com/cohe4ko/BotVa) Self-hosted multi-bot Telegram platform powered by Claude AI with MCP integration, persistent memory, and team coordination.
 
 ### Inline Bots
 


### PR DESCRIPTION
## Summary

- Adds [BotVa](https://github.com/cohe4ko/BotVa) to the Bots section
- BotVa is a self-hosted multi-bot Telegram platform powered by Claude AI with MCP integration, persistent memory, and team coordination
- MIT licensed, open source

## Details

- Repository: https://github.com/cohe4ko/BotVa
- License: MIT
- Entry added at the bottom of the Bots category, following existing format with Open Source link