### PR TITLE
Add DeepAlpha Bot - AI Crypto Trading

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ Join our supergroup on Telegram: [![@awesometelegram](https://img.shields.io/bad
 * [ShopSavvy](https://github.com/shopsavvy/telegram-shopsavvy-bot) – Open-source, self-hosted bot for product search, price comparison across retailers, and trending deal discovery.
 * [Cyber Collector](https://t.me/cybercollectorbot) – Bot to download videos from TikTok, Instagram, YouTube, X (Twitter) and Facebook.
 
+* [@DeepAlphaVault_bot](https://t.me/DeepAlphaVault_bot) – AI crypto trading bot. Manage AI, Grid, and DCA bots across 12 exchanges from Telegram. Check positions, PnL, balance. Free 7-day trial. [Website](https://deepalphabot.com)
+
 ### Inline Bots
 
 In all inline bots, you need to enter @botname, type words and wait for response (~1 second)

--- a/README.md
+++ b/README.md
@@ -56,8 +56,7 @@ Join our supergroup on Telegram: [![@awesometelegram](https://img.shields.io/bad
 * [@SignalDigest_Bot](https://t.me/SignalDigest_Bot) - AI-curated daily news digest for Telegram. Pick your topics (AI, tech, markets, crypto, world news) and receive 5–10 curated stories with source citations every day. Free tier: 3 stories/day. Paid: $5/month.
 * [ShopSavvy](https://github.com/shopsavvy/telegram-shopsavvy-bot) – Open-source, self-hosted bot for product search, price comparison across retailers, and trending deal discovery.
 * [Cyber Collector](https://t.me/cybercollectorbot) – Bot to download videos from TikTok, Instagram, YouTube, X (Twitter) and Facebook.
-
-* [@DeepAlphaVault_bot](https://t.me/DeepAlphaVault_bot) – AI crypto trading bot. Manage AI, Grid, and DCA bots across 12 exchanges from Telegram. Check positions, PnL, balance. Free 7-day trial. [Website](https://deepalphabot.com)
+* [@DeepAlphaVault_bot](https://t.me/DeepAlphaVault_bot) – AI crypto trading bot. Manage AI, Grid, and DCA bots across 12 exchanges from Telegram. Check positions, PnL, and balance.
 
 ### Inline Bots
 


### PR DESCRIPTION
## Adding DeepAlpha Bot (@DeepAlphaVault_bot)

AI-powered crypto trading bot manageable entirely from Telegram:

- **3 bot types**: AI Bot, Grid Bot, DCA Bot
- **12 exchanges**: Bybit, Binance, OKX, MEXC, BingX, HTX & more
- **Commands**: /status, /start_bot, /stop_bot, /balance, /pnl, /trades
- **Non-custodial**: funds stay on user's exchange
- **Free 7-day trial**

Telegram: https://t.me/DeepAlphaVault_bot
Website: https://deepalphabot.com
GitHub: https://github.com/stefanoviana/deepalpha