### PR TITLE
Add @userid_checkbot — Telegram User/Chat/Channel ID lookup bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ Join our supergroup on Telegram: [![@awesometelegram](https://img.shields.io/bad
 * [Cyber Collector](https://t.me/cybercollectorbot) – Bot to download videos from TikTok, Instagram, YouTube, X (Twitter) and Facebook.
 * [MoniPayBot](https://t.me/monipaybot) – Gasless stablecoin payments, tipping, and gated access subscription management on Telegram. Send USDC, USDT, or USDT0 to any @username across Base, BSC, Celo, Ink, and Solana. Non-custodial.
 
+
+* [@userid_checkbot](https://t.me/userid_checkbot) - Instantly find your Telegram User ID, Chat ID, or Channel ID. Also available at [telegramuserid.com](https://telegramuserid.com).
 ### Inline Bots
 
 In all inline bots, you need to enter @botname, type words and wait for response (~1 second)

--- a/README.md
+++ b/README.md
@@ -57,9 +57,8 @@ Join our supergroup on Telegram: [![@awesometelegram](https://img.shields.io/bad
 * [ShopSavvy](https://github.com/shopsavvy/telegram-shopsavvy-bot) – Open-source, self-hosted bot for product search, price comparison across retailers, and trending deal discovery.
 * [Cyber Collector](https://t.me/cybercollectorbot) – Bot to download videos from TikTok, Instagram, YouTube, X (Twitter) and Facebook.
 * [MoniPayBot](https://t.me/monipaybot) – Gasless stablecoin payments, tipping, and gated access subscription management on Telegram. Send USDC, USDT, or USDT0 to any @username across Base, BSC, Celo, Ink, and Solana. Non-custodial.
+* [@userid_checkbot](https://t.me/userid_checkbot) – Instantly find your Telegram User ID, Chat ID, or Channel ID. Also available at [telegramuserid.com](https://telegramuserid.com).
 
-
-* [@userid_checkbot](https://t.me/userid_checkbot) - Instantly find your Telegram User ID, Chat ID, or Channel ID. Also available at [telegramuserid.com](https://telegramuserid.com).
 ### Inline Bots
 
 In all inline bots, you need to enter @botname, type words and wait for response (~1 second)


### PR DESCRIPTION
Adding @userid_checkbot to the Bots section.

**Bot:** [@userid_checkbot](https://t.me/userid_checkbot)
**Website:** [telegramuserid.com](https://telegramuserid.com)

A utility bot that instantly finds your Telegram User ID, Chat ID, or Channel ID. No setup required — just start the bot and it returns your IDs.

Also available as a web tool at telegramuserid.com.