### PR TITLE
Add tgkit — free in-browser toolbox for Telegram developers

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ Challenge your friends in MULTIPLAYER mode!
  * [Telegram Media Downloader](https://github.com/rfsbraz/telegram-downloader) – Self-hosted daemon that automatically downloads media from Telegram channels, groups, and forum topics.
  * [telepipe](https://github.com/Linuxmaster14/telepipe) – Lightweight Bash utility for piping command output to Telegram chats. Automatically switches between message and file modes based on content length.
  * [Untether](https://github.com/littlebearapps/untether) – Self-hosted bot bridging AI coding agents to Telegram with inline keyboards, voice transcription, real-time streaming, and file transfer.
+ * [tgkit](https://tgkit.io) – Free in-browser toolbox for Telegram bot developers and channel admins: ID & username resolver, bot token tester (getMe), inline keyboard builder, MarkdownV2 escaper with live preview, sticker pack downloader, channel-post link parser, webhook tester with sample Update payloads, getUpdates viewer, UTM-attributed start-param builder, link preview tester, error code reference, and a live api.telegram.org status page. Credentials never leave your browser where possible.
 
 ## Themes
 


### PR DESCRIPTION
## What

Adding **[tgkit](https://tgkit.io)** to the existing `## Tools` section. Sits alongside the other web/CLI utilities already listed there (telegram-id, telegram-finder, telegram-send, etc.) and complements them with a broader in-browser toolbox.

## Why it fits

tgkit covers 15+ utilities relevant to Telegram bot developers and channel admins, including some scenarios not covered by other tools in the list:

- ID & username resolver, username availability checker
- Bot token verifier (`getMe`)
- Inline keyboard builder → ready-to-paste `reply_markup` JSON
- MarkdownV2 escaper with live preview (fixes the perennial `Bad Request: can't parse entities`)
- Sticker pack downloader (WEBP/TGS/WEBM in a ZIP, browser-side)
- Channel-post link parser (`t.me/c/X/Y` → `chat_id`, `message_id`, etc.)
- Webhook tester with 8 sample `Update` payloads
- `getUpdates` viewer (pretty table instead of raw JSON)
- UTM-attributed bot-start-param builder with Python/Telegraf decoders
- Telegram error-code reference (FLOOD_WAIT, PEER_ID_INVALID, …)
- `api.telegram.org` live status page

Where possible everything runs client-side — bot tokens never touch the tgkit servers.

## Disclosure

I'm the author. Submitting as self-disclosure per the implicit norm in `contributing.md`. Happy to revise the entry length or position if you'd prefer.

Thanks for maintaining this list — used it as a reference plenty of times over the years.