### PR TITLE
Add AccountCreatedBot to the Bots section

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Join our supergroup on Telegram: [![@awesometelegram](https://img.shields.io/bad
 * [ShopSavvy](https://github.com/shopsavvy/telegram-shopsavvy-bot) – Open-source, self-hosted bot for product search, price comparison across retailers, and trending deal discovery.
 * [Cyber Collector](https://t.me/cybercollectorbot) – Bot to download videos from TikTok, Instagram, YouTube, X (Twitter) and Facebook.
 * [MoniPayBot](https://t.me/monipaybot) – Gasless stablecoin payments, tipping, and gated access subscription management on Telegram. Send USDC, USDT, or USDT0 to any @username across Base, BSC, Celo, Ink, and Solana. Non-custodial.
+* [@AccountCreatedBot](https://t.me/AccountCreatedBot) – Get Telegram account information and estimated creation dates.
 
 ### Inline Bots
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Join our supergroup on Telegram: [![@awesometelegram](https://img.shields.io/bad
 * [ShopSavvy](https://github.com/shopsavvy/telegram-shopsavvy-bot) – Open-source, self-hosted bot for product search, price comparison across retailers, and trending deal discovery.
 * [Cyber Collector](https://t.me/cybercollectorbot) – Bot to download videos from TikTok, Instagram, YouTube, X (Twitter) and Facebook.
 * [MoniPayBot](https://t.me/monipaybot) – Gasless stablecoin payments, tipping, and gated access subscription management on Telegram. Send USDC, USDT, or USDT0 to any @username across Base, BSC, Celo, Ink, and Solana. Non-custodial.
-* [@AccountCreatedBot](https://t.me/AccountCreatedBot) – Get Telegram account information and estimated creation dates.
+* [@AccountCreatedBot](https://t.me/AccountCreatedBot) – Estimate Telegram account creation dates via forwarded messages, usernames, or contacts. Supports multiple languages.
 
 ### Inline Bots
 


### PR DESCRIPTION
Add AccountCreatedBot to the bots list.

https://t.me/AccountCreatedBot

Get Telegram account information and estimated creation dates.

Supports multiple languages to help review account details, identify account age, and reduce risks in deals and communication.

Supported methods:
• Your account
• Shared accounts
• Forwarded messages
• Contacts
• Usernames
• Telegram links