### PR TITLE
Add @dev_pinger_bot to Bots

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Join our supergroup on Telegram: [![@awesometelegram](https://img.shields.io/bad
 * [ShopSavvy](https://github.com/shopsavvy/telegram-shopsavvy-bot) – Open-source, self-hosted bot for product search, price comparison across retailers, and trending deal discovery.
 * [Cyber Collector](https://t.me/cybercollectorbot) – Bot to download videos from TikTok, Instagram, YouTube, X (Twitter) and Facebook.
 * [MoniPayBot](https://t.me/monipaybot) – Gasless stablecoin payments, tipping, and gated access subscription management on Telegram. Send USDC, USDT, or USDT0 to any @username across Base, BSC, Celo, Ink, and Solana. Non-custodial.
-* [@dev_pinger_bot](https://t.me/dev_pinger_bot) – [Open Source](https://github.com/Guck111/devpinger) notification inbox for GitHub PRs, CI failures, and Jira issues with inline approve, comment, transition, and mute actions. Self-hostable, MIT, Node.js.
+* [@dev_pinger_bot](https://t.me/dev_pinger_bot) – [Open Source](https://github.com/Guck111/devpinger) Notification inbox for GitHub PRs, CI failures, and Jira issues with inline approve, comment, transition, and mute actions. Self-hostable, MIT, Node.js.
 
 ### Inline Bots
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Join our supergroup on Telegram: [![@awesometelegram](https://img.shields.io/bad
 * [ShopSavvy](https://github.com/shopsavvy/telegram-shopsavvy-bot) – Open-source, self-hosted bot for product search, price comparison across retailers, and trending deal discovery.
 * [Cyber Collector](https://t.me/cybercollectorbot) – Bot to download videos from TikTok, Instagram, YouTube, X (Twitter) and Facebook.
 * [MoniPayBot](https://t.me/monipaybot) – Gasless stablecoin payments, tipping, and gated access subscription management on Telegram. Send USDC, USDT, or USDT0 to any @username across Base, BSC, Celo, Ink, and Solana. Non-custodial.
+* [@dev_pinger_bot](https://t.me/dev_pinger_bot) – [Open Source](https://github.com/Guck111/devpinger) notification inbox for GitHub PRs, CI failures, and Jira issues with inline approve, comment, transition, and mute actions. Self-hostable, MIT, Node.js.
 
 ### Inline Bots
 


### PR DESCRIPTION
Hi, thanks for maintaining this list.

Adding [@dev_pinger_bot](https://t.me/dev_pinger_bot) — an open-source Telegram bot that consolidates engineering notifications (GitHub PRs, reviews, comments, CI failures; Jira Cloud issues, comments, status changes) into one Telegram chat with inline approve / comment / transition / mute buttons.

Source code: https://github.com/Guck111/devpinger (MIT)

Checklist from `contributing.md`:
- [x] Searched previous suggestions — no existing entry for this bot
- [x] Individual pull request for a single suggestion
- [x] Format: `[List Name](link)`
- [x] Added to the bottom of the relevant category (`## Bots`)
- [x] Useful PR/commit title (not "Update readme.md")
- [x] Commit body contains a link to the repository