### PR TITLE
Add tgwatch (zero-infra monitoring for bots/userbots)

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ Challenge your friends in MULTIPLAYER mode!
  * [telepipe](https://github.com/Linuxmaster14/telepipe) – Lightweight Bash utility for piping command output to Telegram chats. Automatically switches between message and file modes based on content length.
  * [Untether](https://github.com/littlebearapps/untether) – Self-hosted bot bridging AI coding agents to Telegram with inline keyboards, voice transcription, real-time streaming, and file transfer.
  * [teleping](https://github.com/yerdaulet-damir/teleping) – Production observability for Node.js/TypeScript: structured alerts, smart batching, quiet hours, and components (card/table/progress/checklist) — zero dependencies.
+ * [tgwatch](https://github.com/assinscreedFC/tgwatch) – Zero-infra health monitoring for aiogram bots and Telethon userbots: account health (restricted/banned/dead session), native Telegram alerts, SQLite, no Prometheus/Grafana. Python.
 
 ## Themes
 


### PR DESCRIPTION
Adds **tgwatch** under Tools.

Zero-infra health monitoring for aiogram bots and Telethon userbots: alive/dead heartbeat, message/error/FloodWait counters, userbot account-health classification (restricted/banned/dead session), and native Telegram alerts. Local SQLite, no Prometheus/Grafana. Base install has zero runtime deps; aiogram/telethon are optional extras. MIT, pip-installable.

- Repo: https://github.com/assinscreedFC/tgwatch
- PyPI: https://pypi.org/project/tgwatch/