### PR TITLE
Add DeFiKit Bot Maker

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ Challenge your friends in MULTIPLAYER mode!
  * [telepipe](https://github.com/Linuxmaster14/telepipe) – Lightweight Bash utility for piping command output to Telegram chats. Automatically switches between message and file modes based on content length.
  * [Untether](https://github.com/littlebearapps/untether) – Self-hosted bot bridging AI coding agents to Telegram with inline keyboards, voice transcription, real-time streaming, and file transfer.
  * [teleping](https://github.com/yerdaulet-damir/teleping) – Production observability for Node.js/TypeScript: structured alerts, smart batching, quiet hours, and components (card/table/progress/checklist) — zero dependencies.
+ * [DeFiKit Bot Maker](https://defikit.net) – Open-source Telegram bot template for creating and managing crypto tokens across Base, Ethereum, and other EVM chains. Self-hosted, white-label, or SaaS.
 
 ## Themes
 


### PR DESCRIPTION
## What this PR does

Adds [DeFiKit Bot Maker](https://defikit.net) to the **Tools** section.

DeFiKit Bot Maker is an open-source Telegram bot template for creating and managing crypto tokens across Base, Ethereum, and other EVM chains.

### Checklist
- [x] Link is added to the bottom of the relevant category per CONTRIBUTING.md
- [x] Format matches existing entries
- [x] Description is factual and concise
- [x] Product website is live