### PR TITLE
Add @codexHuddbot bot and codex-reset CLI tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Join our supergroup on Telegram: [![@awesometelegram](https://img.shields.io/bad
 * [@zodiac_bot](https://telegram.me/zodiac_bot) – Bot shows your horoscope.
 * [@movie_adviser_bot](https://telegram.me/movie_adviser_bot) – Advises best rated movie everyday.
 * [@Cashgamebot](https://telegram.me/Cashgamebot) – First ever online casino in telegram bot.
+* [@codexHuddbot](https://t.me/codexHuddbot) – [Open Source](https://github.com/aaamosh/codex-hud) bot for matching OpenAI Codex referral links one-to-one, on demand.
 * [@github_gist_bot](https://t.me/github_gist_bot) – Bot uploads text and documents to GitHub Gist.
 * [@nosticker_bot](https://t.me/nosticker_bot) – Removes any sticker posted to the group
 * [@daysandbox_bot](https://t.me/daysandbox_bot) – Removes link cointaining posts from user that joined group in recent 24 hours
@@ -219,6 +220,7 @@ Challenge your friends in MULTIPLAYER mode!
  * [Telegram Media Downloader](https://github.com/rfsbraz/telegram-downloader) – Self-hosted daemon that automatically downloads media from Telegram channels, groups, and forum topics.
  * [Telegram-Archive](https://github.com/GeiserX/Telegram-Archive) – Docker-based tool for archiving Telegram channels and groups with full media support, incremental backups, and a local web viewer.
  * [telepipe](https://github.com/Linuxmaster14/telepipe) – Lightweight Bash utility for piping command output to Telegram chats. Automatically switches between message and file modes based on content length.
+ * [codex-reset](https://github.com/aaamosh/codex-reset) – [Open Source](https://github.com/aaamosh/codex-reset) CLI tool for consuming banked rate-limit reset credits from the OpenAI Codex API, for headless Linux users.
  * [Untether](https://github.com/littlebearapps/untether) – Self-hosted bot bridging AI coding agents to Telegram with inline keyboards, voice transcription, real-time streaming, and file transfer.
  * [teleping](https://github.com/yerdaulet-damir/teleping) – Production observability for Node.js/TypeScript: structured alerts, smart batching, quiet hours, and components (card/table/progress/checklist) — zero dependencies.
 


### PR DESCRIPTION
Adds two open-source tools (both MIT, both by aaamosh):

**Bots section:**
- **[@codexHuddbot](https://t.me/codexHuddbot)** — Telegram bot for one-to-one matching of OpenAI Codex referral links. Users submit their referral link; others claim it on demand. No race conditions, no wasted referrals. ~500 LOC, Python aiohttp + SQLite.

**Tools section:**
- **[codex-reset](https://github.com/aaamosh/codex-reset)** — CLI tool for Linux/headless users to consume banked rate-limit reset credits via the OpenAI Codex API. Solves the problem of accumulated credits that never get spent because the GUI popup only appears in-editor.