### PR TITLE
Add telegram-forwarder to Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ Challenge your friends in MULTIPLAYER mode!
  * [Untether](https://github.com/littlebearapps/untether) – Self-hosted bot bridging AI coding agents to Telegram with inline keyboards, voice transcription, real-time streaming, and file transfer.
  * [tgwatch](https://github.com/assinscreedFC/tgwatch) – Zero-infra health monitoring for aiogram bots and Telethon userbots: account health (restricted/banned/dead session), native Telegram alerts, SQLite, no Prometheus/Grafana. Python.
  * [OpenPaw](https://github.com/daxaur/openpaw) – Open-source CLI tool (`npx pawmode`) with a built-in Telegram bridge to chat with Claude from your phone. Includes 38 skills covering email, calendar, Spotify, smart home, GitHub, Slack and more.
+ * [telegram-forwarder](https://github.com/awdr74100/telegram-forwarder) – Many-to-many CLI forwarder that mirrors messages and media between chats, with per-route content filters, recovery of posts deleted at the source, and automatic FloodWait handling. Single self-hosted Rust binary, no bot and no database.
 
 ## Themes
 


### PR DESCRIPTION
### What

Adds [telegram-forwarder](https://github.com/awdr74100/telegram-forwarder) to the **Tools** section.

### About

A self-hosted CLI that mirrors messages and media from any number of Telegram
chats into any number of others. Each route has its own content filter and
delivery mode, source and target chats are picked from an interactive list of
the account's own dialogs (no manual ID entry), messages are snapshotted before
any filtering so a post deleted seconds after publication still arrives, and
FloodWait is handled with reactive backoff.

- Repo: https://github.com/awdr74100/telegram-forwarder
- License: MIT
- Stack: Rust (grammers / MTProto)

### Changes since the first push

- Rebased onto the current `master`; the entry now sits at the bottom of **Tools**.
- Uses an en dash (`–`) as the separator and the description ends with a period,
  as requested in review.
