### PR TITLE
Add Filaxy Herald to Bots

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Join our supergroup on Telegram: [![@awesometelegram](https://img.shields.io/bad
 * [TikTok Live Recorder | TikRec](https://t.me/tikrec_live_bot) – [Open Source](https://github.com/Michele0303/tiktok-live-recorder) bot that records TikTok live streams and delivers the MP4 to your Telegram chat. Free, with a public archive at [tikrec.com](https://tikrec.com).
 * [First Officer Bot](https://t.me/first_officer_bot) - Aviation bot to access real-time weather (METAR, TAF, SIGMET, SIGWX), flight data, aviation calculations, VATSIM/IVAO network data, NOTAMs, and other pilot resources.
 * [Telegram Delay Channel Cloner](https://github.com/GeiserX/telegram-delay-channel-cloner) – Self-hosted bot that re-broadcasts messages from one of your own channels to another after a configurable delay (requires bot admin rights on both source and target channels).
+* [Filaxy Herald](https://github.com/othmarodev/filaxy-herald) – [Open Source](https://github.com/othmarodev/filaxy-herald) build-in-public bot that turns your GitHub activity into short posts. It drafts an update about what you shipped and sends it to you on Telegram with ✅/❌ buttons; approved posts are published to X. Includes a safety guardrail that strips secrets before anything is shown. Self-hostable, MIT, Node.js.
 
 ### Inline Bots
 


### PR DESCRIPTION
Hi @ebertti, thanks for maintaining this list 🙏

Adding **Filaxy Herald** to the **Bots** section.

It's an open-source, self-hostable Telegram bot that turns your GitHub activity into build-in-public posts: it drafts an update about what you shipped and sends it to you on Telegram with ✅/❌ buttons. Approved posts are published to X. It also has a safety guardrail that strips secrets before anything is shown.

**Why it fits:** it's an OSS, self-hosted Telegram bot where Telegram is the core approval UX — the same shape as existing entries like `@dev_pinger_bot` (GitHub/CI notifications with inline actions) and `Telegram Delay Channel Cloner`.

- Repo: https://github.com/othmarodev/filaxy-herald
- License: MIT · Node.js

One-line addition, alphabetical-agnostic (appended to the end of the Bots list like recent entries). Happy to adjust wording or placement if you'd prefer.