### PR TITLE
Add TGMania to Telegram Directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,7 @@ Challenge your friends in MULTIPLAYER mode!
 * [statiko.io](https://statiko.io/) – Telegram public channel analytics and directory platform. Continuously monitors post editing and deletion, provides detailed statistics and insights for channels.
 * [TDirectory](https://tdirectory.me/) – Search popular Telegram Channels, Groups and Bots
 * [Telegram Grupos](https://www.telegram-grupos.com/) – Brazilian directory of verified Telegram groups, channels and bots, organized by category and city (PT/EN/ES).
+* [TGMania](https://tgmania.com/) – Searchable directory of 70,000+ Telegram channels and groups by category, country and language, with a 0-10 quality score per channel and a free public JSON API.
 * [tgram.io](https://tgram.io/) – Telegram groups list, telegram group chat, telegram chat rooms, telegram groups to join
 
 ## Community Forums


### PR DESCRIPTION
Adding [TGMania](https://tgmania.com/) to the **Telegram Directory** section.

TGMania is a searchable web directory of 70,000+ Telegram channels and groups, organized by category, country and language, with a 0-10 quality score per channel and a free public JSON API (`/api/channels`). It fits directly alongside the existing entries like TDirectory, DirectoryTG and tgram.io.

Single entry, placed alphabetically, follows the existing `* [Name](url) – description` format.