### PR TITLE
Add Weight Goal Bot to Bots

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Join our supergroup on Telegram: [![@awesometelegram](https://img.shields.io/bad
 * [ShopSavvy](https://github.com/shopsavvy/telegram-shopsavvy-bot) – Open-source, self-hosted bot for product search, price comparison across retailers, and trending deal discovery.
 * [Telegram Delay Channel Cloner](https://github.com/GeiserX/telegram-delay-channel-cloner) – Self-hosted bot that re-broadcasts messages from one of your own channels to another after a configurable delay (requires bot admin rights on both source and target channels).
 * [TikTok Live Recorder | TikRec](https://t.me/tikrec_live_bot) – [Open Source](https://github.com/Michele0303/tiktok-live-recorder) bot that records TikTok live streams and delivers the MP4 to your Telegram chat. Free, with a public archive at [tikrec.com](https://tikrec.com).
+* [@my_weight_goal_bot](https://t.me/my_weight_goal_bot) – [Open Source](https://github.com/IgorShadurin/weight-telegram-bot) bilingual group bot for photo-backed weekly weight goals, progress charts, reminders, and achievements.
 
 ### Inline Bots
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Join our supergroup on Telegram: [![@awesometelegram](https://img.shields.io/bad
 * [ShopSavvy](https://github.com/shopsavvy/telegram-shopsavvy-bot) – Open-source, self-hosted bot for product search, price comparison across retailers, and trending deal discovery.
 * [Telegram Delay Channel Cloner](https://github.com/GeiserX/telegram-delay-channel-cloner) – Self-hosted bot that re-broadcasts messages from one of your own channels to another after a configurable delay (requires bot admin rights on both source and target channels).
 * [TikTok Live Recorder | TikRec](https://t.me/tikrec_live_bot) – [Open Source](https://github.com/Michele0303/tiktok-live-recorder) bot that records TikTok live streams and delivers the MP4 to your Telegram chat. Free, with a public archive at [tikrec.com](https://tikrec.com).
-* [@my_weight_goal_bot](https://t.me/my_weight_goal_bot) – [Open Source](https://github.com/IgorShadurin/weight-telegram-bot) group bot for photo-backed weekly weight goals, progress charts, reminders, and achievements in English, Russian, and Chinese.
+* [@my_weight_goal_bot](https://t.me/my_weight_goal_bot) – [Apache-2.0 open-source](https://github.com/IgorShadurin/weight-telegram-bot) group bot for photo-backed weekly weight goals, charts, reminders, and 53 achievements in nine languages.
 
 ### Inline Bots
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Join our supergroup on Telegram: [![@awesometelegram](https://img.shields.io/bad
 * [ShopSavvy](https://github.com/shopsavvy/telegram-shopsavvy-bot) – Open-source, self-hosted bot for product search, price comparison across retailers, and trending deal discovery.
 * [Telegram Delay Channel Cloner](https://github.com/GeiserX/telegram-delay-channel-cloner) – Self-hosted bot that re-broadcasts messages from one of your own channels to another after a configurable delay (requires bot admin rights on both source and target channels).
 * [TikTok Live Recorder | TikRec](https://t.me/tikrec_live_bot) – [Open Source](https://github.com/Michele0303/tiktok-live-recorder) bot that records TikTok live streams and delivers the MP4 to your Telegram chat. Free, with a public archive at [tikrec.com](https://tikrec.com).
-* [@my_weight_goal_bot](https://t.me/my_weight_goal_bot) – [Open Source](https://github.com/IgorShadurin/weight-telegram-bot) bilingual group bot for photo-backed weekly weight goals, progress charts, reminders, and achievements.
+* [@my_weight_goal_bot](https://t.me/my_weight_goal_bot) – [Open Source](https://github.com/IgorShadurin/weight-telegram-bot) group bot for photo-backed weekly weight goals, progress charts, reminders, and achievements in English, Russian, and Chinese.
 
 ### Inline Bots
 


### PR DESCRIPTION
## Summary

Adds [Weight Goal Bot](https://t.me/my_weight_goal_bot) ([source](https://github.com/IgorShadurin/weight-telegram-bot)) to the Bots section.

I maintain this Apache-2.0-licensed Telegram group bot. Its complete interface is naturally adapted for English, Russian, Chinese, Spanish, Portuguese, German, French, Japanese, and Indonesian; it uses photo-backed weigh-ins and provides weekly checkpoints, progress charts, reminders, and 53 achievements.

## Verification

- [x] The [live bot](https://t.me/my_weight_goal_bot) link resolves.
- [x] The [source repository](https://github.com/IgorShadurin/weight-telegram-bot) is public and licensed under Apache-2.0.
- [x] I searched this repository for an existing duplicate.
- [x] This change follows a single bottom-of-section entry with an em dash, live bot link, and open-source link.