### PR TITLE
Add TGboard to Telegram Directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,9 +329,9 @@ Challenge your friends in MULTIPLAYER mode!
 * [statiko.io](https://statiko.io/) – Telegram public channel analytics and directory platform. Continuously monitors post editing and deletion, provides detailed statistics and insights for channels.
 * [TDirectory](https://tdirectory.me/) – Search popular Telegram Channels, Groups and Bots
 * [Telegram Grupos](https://www.telegram-grupos.com/) – Brazilian directory of verified Telegram groups, channels and bots, organized by category and city (PT/EN/ES).
+* [TGboard](https://tgboard.com/en) – Multilingual directory for discovering Telegram channels, groups, bots, Mini Apps, and sticker packs.
 * [TGMania](https://tgmania.com/) – Searchable directory of 70,000+ Telegram channels and groups by category, country and language, with a 0-10 quality score per channel and a free public JSON API.
 * [tgram.io](https://tgram.io/) – Telegram groups list, telegram group chat, telegram chat rooms, telegram groups to join
-* [TGboard](https://tgboard.com/en) – Multilingual directory for discovering Telegram channels, groups, bots, Mini Apps, and sticker packs.
 
 ## Community Forums
 

--- a/README.md
+++ b/README.md
@@ -331,6 +331,7 @@ Challenge your friends in MULTIPLAYER mode!
 * [Telegram Grupos](https://www.telegram-grupos.com/) – Brazilian directory of verified Telegram groups, channels and bots, organized by category and city (PT/EN/ES).
 * [TGMania](https://tgmania.com/) – Searchable directory of 70,000+ Telegram channels and groups by category, country and language, with a 0-10 quality score per channel and a free public JSON API.
 * [tgram.io](https://tgram.io/) – Telegram groups list, telegram group chat, telegram chat rooms, telegram groups to join
+* [TGboard](https://tgboard.com/en) – Multilingual directory for discovering Telegram channels, groups, bots, Mini Apps, and sticker packs.
 
 ## Community Forums
 


### PR DESCRIPTION
## Checklist

- [x] I've read the [contributing guidelines](contributing.md)
- [x] Entry follows the required `* [Name](https://url) – Single sentence description.` format
- [x] Entry is in alphabetical order in the Telegram Directory section
- [x] This PR adds a single entry
- [x] The link is publicly accessible

## Section

- [x] Telegram Directory

## Why this belongs

TGboard is a public multilingual directory for discovering Telegram channels, groups, bots, Mini Apps, and sticker packs. This PR adds one neutral description and one direct link.