### PR TITLE
Add Anystat to Python bot libraries section

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ Challenge your friends in MULTIPLAYER mode!
 
 #### Python
  * [AIOGram](https://github.com/aiogram/aiogram) – A pretty simple and fully asynchronous framework for Telegram Bot API.
+ * [Anystat](https://github.com/ivan-nechaev/anystat-python) – Privacy-first analytics SDK for aiogram 3 bots: auto-tracking, custom events and /start deep-link attribution.
  * [django-telegram-bot](https://github.com/jlmadurga/django-telegram-bot) – Django app to write Telegram bots. Just define commands and how to handle them.
  * [ErisPulse](https://github.com/ErisPulse/ErisPulse) – Async-first Python bot framework with Telegram support, unified adapter interface, and plugin system; also supports multiple other platforms.
  * [Folds](https://github.com/tm-a-t/folds) – An elegant and scalable framework for bots.


### PR DESCRIPTION
Added Anystat SDK for aiogram 3 bots to the list of Python bot libraries.

## Checklist

Before submitting, please confirm:

- [ ] I've read the [contributing guidelines](contributing.md)
- [ ] My entry follows the exact format: `* [Name](https://url) – Single sentence description.`
  - Uses `–` (en dash), not `-` or `—`
  - Description ends with a period `.`
  - Link is a direct URL (no redirect shorteners)
- [ ] I placed the entry in **alphabetical order** within the correct section
- [ ] This is a **single entry per PR** (one item only)
- [ ] The link is publicly accessible

## Section

Which section does this entry belong to?

- [ ] Bots
- [ ] Inline Bots
- [ ] Games
- [ ] Bot Libs (specify language below)
- [ ] Tools
- [ ] Themes
- [ ] Groups
- [ ] Channels
- [ ] Bot Stores
- [ ] Telegram Directory
- [ ] Other: ___________

## Not accepted

We do not accept entries that:

- Contain **adult/explicit content**
- Promote **gambling, betting, or games of chance**
- Are **spam, scam, or self-promotion** without clear public value
- Are **closed-source** without a clear description of what the tool does
- Have **broken or inaccessible links**

---

> **Why alphabetical order?**
> Entries must be inserted in alphabetical order (case-insensitive, ignoring `@` and `[`).
> This keeps the list consistent and avoids merge conflicts with other PRs targeting the same section.
