### PR TITLE
Add Mastros to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ Challenge your friends in MULTIPLAYER mode!
  * [BanOnExit](https://github.com/BotMaven/BanOnExit) – Automatically ban users who join and leave your Telegram groups or channels within a configurable time frame
  * [Jellyfin Telegram Channel Sync](https://github.com/GeiserX/jellyfin-telegram-channel-sync) – Syncs Jellyfin user access with Telegram channel membership.
  * [Maltego Telegram](https://github.com/vognik/maltego-telegram) – Rich Set of Entities & Transforms for OSINT on Telegram with Maltego
+ * [Mastros](https://www.mastros.online/telegram-scraper) – Chrome extension that exports Telegram Web members, messages, contacts, and media to CSV, JSON, or JSONL, processed locally in your browser.
  * [mtproto-manager](https://github.com/vdistortion/mtproto-manager) – A Bash script for managing MTProto proxies on Linux with Docker, FakeTLS, and multi-user support.
  * [shell2telegram](https://github.com/msoap/shell2telegram) – Telegram bot constructor from command-line.
  * [Telegram Media Downloader](https://github.com/rfsbraz/telegram-downloader) – Self-hosted daemon that automatically downloads media from Telegram channels, groups, and forum topics.


### PR DESCRIPTION
Adds Mastros to the Tools section.

Confirmed against the checklist: entry uses the exact format with an en dash and a trailing period; the link is a direct URL (https://www.mastros.online/telegram-scraper) with no redirect shortener; it is placed in alphabetical order (after Maltego Telegram, before mtproto-manager); single entry per PR; and the link is publicly accessible.

Mastros is a Chrome extension that exports Telegram Web members, messages, contacts, and media to CSV, JSON, or JSONL, processed locally in the browser. It performs user-initiated exports of data you already have access to.