### PR TITLE
Add TGArchiveManager

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,9 +260,9 @@ Challenge your friends in MULTIPLAYER mode!
  * [telepipe](https://github.com/Linuxmaster14/telepipe) – Lightweight Bash utility for piping command output to Telegram chats. Automatically switches between message and file modes based on content length.
  * [Teleton](https://github.com/TONresistor/teleton-agent) – Autonomous AI agent for Telegram with TON blockchain integration, 15 LLM providers, plugin SDK, and hybrid RAG memory. Self-hosted.
  * [TG Multi-Service](https://tg.api.afonin-lisa.ru/) – SaaS REST API platform for managing multiple Telegram and Max accounts with webhook support, media handling, and QR-code authorization.
- * [TGArchiveManager](https://github.com/q909717714/TGArchiveManager) – Windows desktop app for compliant Telegram archiving, search, media backup, and structured export.
  * [TGPy](https://tgpy.dev) – Run Python code in Telegram chats. Automate your messages and explore Telegram API
  * [Untether](https://github.com/littlebearapps/untether) – Self-hosted bot bridging AI coding agents to Telegram with inline keyboards, voice transcription, real-time streaming, and file transfer.
+ * [TGArchiveManager](https://github.com/q909717714/TGArchiveManager) – Windows desktop app for compliant Telegram archiving, search, media backup, and structured export.
 
 ## Themes
 

--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ Challenge your friends in MULTIPLAYER mode!
  * [telepipe](https://github.com/Linuxmaster14/telepipe) – Lightweight Bash utility for piping command output to Telegram chats. Automatically switches between message and file modes based on content length.
  * [Teleton](https://github.com/TONresistor/teleton-agent) – Autonomous AI agent for Telegram with TON blockchain integration, 15 LLM providers, plugin SDK, and hybrid RAG memory. Self-hosted.
  * [TG Multi-Service](https://tg.api.afonin-lisa.ru/) – SaaS REST API platform for managing multiple Telegram and Max accounts with webhook support, media handling, and QR-code authorization.
+ * [TGArchiveManager](https://github.com/q909717714/TGArchiveManager) – Windows desktop app for compliant Telegram archiving, search, media backup, and structured export.
  * [TGPy](https://tgpy.dev) – Run Python code in Telegram chats. Automate your messages and explore Telegram API
  * [Untether](https://github.com/littlebearapps/untether) – Self-hosted bot bridging AI coding agents to Telegram with inline keyboards, voice transcription, real-time streaming, and file transfer.
 


### PR DESCRIPTION
Adds TGArchiveManager to the Tools section.

TGArchiveManager is an MIT-licensed Windows desktop application built with PySide6 and Telethon for compliant Telegram archiving, search, media backup, and structured export. I am the project maintainer.

## Checklist

- [x] I've read the [contributing guidelines](contributing.md) and `AGENTS.md`
- [x] My entry follows the exact format: `* [Name](https://url) – Single sentence description.`
  - Uses `–` (en dash)
  - Description ends with a period
  - Link is a direct URL
- [x] I placed the entry at the **bottom of the correct section**, as required by `AGENTS.md` and the automated review
- [x] This is a **single entry per PR**
- [x] The link is publicly accessible

## Section

- [x] Tools
