### PR TITLE
Add Claude Code Daily to Unofficial Channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,8 +294,8 @@ Challenge your friends in MULTIPLAYER mode!
 * [Agile Methods](https://t.me/agilemethods) – Books, blog posts, conferences and much more about agile methods.
 * [bash.im](https://t.me/bash_im) – Everyday quotes from formerly bash.org site
 * [Cateinum](https://t.me/cateinum) – Relaxation channel, fresh cat picture every hour (at exactly XX:00).
-* [Claude Code Daily](https://t.me/DailyClaudeTips) – One practical Claude Code tip per day, written and published end to end by AI agents as an open documented experiment.
 * [CatOps](https://t.me/catops) – News and notes about DevOps, SRE, and more.
+* [Claude Code Daily](https://t.me/DailyClaudeTips) – One practical Claude Code tip per day, written and published end to end by AI agents as an open documented experiment.
 * [Code Stars](https://t.me/code_stars) – Code Stars highlights the most popular GitHub repos from the last hour, helping you discover innovative projects early.
 * [Coding at Night](https://t.me/codingatnight) – Daily news, articles & tools pertaining to programming and technology.
 * [Elixir Formula](https://t.me/elixir_formula) – Telegram channel for elixir developers and other people who interested in Elixir-lang.

--- a/README.md
+++ b/README.md
@@ -294,6 +294,7 @@ Challenge your friends in MULTIPLAYER mode!
 * [Agile Methods](https://t.me/agilemethods) – Books, blog posts, conferences and much more about agile methods.
 * [bash.im](https://t.me/bash_im) – Everyday quotes from formerly bash.org site
 * [Cateinum](https://t.me/cateinum) – Relaxation channel, fresh cat picture every hour (at exactly XX:00).
+* [Claude Code Daily](https://t.me/DailyClaudeTips) – One practical Claude Code tip per day, written and published end to end by AI agents as an open documented experiment.
 * [CatOps](https://t.me/catops) – News and notes about DevOps, SRE, and more.
 * [Code Stars](https://t.me/code_stars) – Code Stars highlights the most popular GitHub repos from the last hour, helping you discover innovative projects early.
 * [Coding at Night](https://t.me/codingatnight) – Daily news, articles & tools pertaining to programming and technology.


### PR DESCRIPTION
Adds Claude Code Daily, an English channel posting one practical Claude Code tip per day. The channel is written and operated end to end by AI agents as an open, documented experiment; the full pipeline is public at https://github.com/ofirozon/self-improving-channel-agent. Unofficial, not affiliated with Anthropic. Entry added alphabetically to Channels > Unofficial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)