### PR TITLE
Add teloxide to Rust bot libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ Challenge your friends in MULTIPLAYER mode!
 #### Rust
 * [Frankenstein](https://github.com/ayrat555/frankenstein) – Telegram bot API client for Rust.
 * [gramme.rs](https://github.com/Lonami/grammers) – A set of Rust libraries for Telegram API, with high-level client interface and MTProto implementation.
+* [teloxide](https://github.com/teloxide/teloxide) – Rust framework for Telegram Bot API bots.
 
 #### Kotlin
 * [kotlin-telegram-bot](https://github.com/seik/kotlin-telegram-bot) – A wrapper for the Telegram Bot API written in Kotlin.


### PR DESCRIPTION
## Summary

Add `teloxide` to the **Bot Libs → Rust** section in `README.md` to include a widely used Rust framework for building Telegram bots.

## Changes

- Added:
  - [`teloxide`](https://github.com/teloxide/teloxide) — Rust framework for Telegram Bot API bots.

## Why

`teloxide` is a popular and actively maintained Rust ecosystem project for Telegram bots, and it fits this list’s scope.
