### PR TITLE
Add telethon-plus to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ Challenge your friends in MULTIPLAYER mode!
  * [telegram-send](https://github.com/rahiel/telegram-send) – Send messages and files over Telegram from the command-line.
  * [teleping](https://github.com/yerdaulet-damir/teleping) – Production observability for Node.js/TypeScript: structured alerts, smart batching, quiet hours, and components (card/table/progress/checklist) — zero dependencies.
  * [telepipe](https://github.com/Linuxmaster14/telepipe) – Lightweight Bash utility for piping command output to Telegram chats. Automatically switches between message and file modes based on content length.
+ * [telethon-plus](https://github.com/psyb0t/docker-telethon-plus) – Self-hosted HTTP + MCP API wrapping a full Telegram user account via Telethon, with async jobs and generated Go/Python clients.
  * [Teleton](https://github.com/TONresistor/teleton-agent) – Autonomous AI agent for Telegram with TON blockchain integration, 15 LLM providers, plugin SDK, and hybrid RAG memory. Self-hosted.
  * [TG Multi-Service](https://tg.api.afonin-lisa.ru/) – SaaS REST API platform for managing multiple Telegram and Max accounts with webhook support, media handling, and QR-code authorization.
  * [TGPy](https://tgpy.dev) – Run Python code in Telegram chats. Automate your messages and explore Telegram API


### PR DESCRIPTION
Adds [telethon-plus](https://github.com/psyb0t/docker-telethon-plus) to the **Tools** section — a self-hosted HTTP + MCP API that wraps a full Telegram user account via Telethon (async jobs, generated Go/Python clients). Sits alphabetically between telepipe and Teleton, matching the existing entry format.