### PR TITLE
Add Portable Telegram Media Downloader

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ Challenge your friends in MULTIPLAYER mode!
  * [Untether](https://github.com/littlebearapps/untether) – Self-hosted bot bridging AI coding agents to Telegram with inline keyboards, voice transcription, real-time streaming, and file transfer.
  * [tgwatch](https://github.com/assinscreedFC/tgwatch) – Zero-infra health monitoring for aiogram bots and Telethon userbots: account health (restricted/banned/dead session), native Telegram alerts, SQLite, no Prometheus/Grafana. Python.
  * [OpenPaw](https://github.com/daxaur/openpaw) – Open-source CLI tool (`npx pawmode`) with a built-in Telegram bridge to chat with Claude from your phone. Includes 38 skills covering email, calendar, Spotify, smart home, GitHub, Slack and more.
+ * [Telegram Media Downloader](https://github.com/swttttt/telegram-media-downloader) – Portable bilingual Windows CLI for downloading complete original-quality Telegram albums, videos, and discussion media from a post URL.
 
 ## Themes
 


### PR DESCRIPTION
Adds a focused entry to the bottom of the **Tools** section for a portable Telegram media downloader.

The project supports complete original-quality albums, videos, and discussion media from a post URL, ships a bilingual Windows executable, and is MIT licensed.

Repository: https://github.com/swttttt/telegram-media-downloader

- [x] Searched existing entries and pull requests
- [x] One suggestion only
- [x] Added to the bottom of the relevant category
- [x] Succinct English description with no trailing whitespace