### PR TITLE
Add Mitup to the Bots section

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Join our supergroup on Telegram: [![@awesometelegram](https://img.shields.io/bad
 * [@KillerBgBot](https://t.me/KillerBgBot) – Background Removal Bot with Bulk Upload Support and No Loss of Quality.
 * [@m00dbot](https://t.me/m00dbot) – [Open Source](https://github.com/dizballanze/m00dbot) bot for self-testing of anxiety and depression.
 * [@MiddlemanBot](https://t.me/MiddlemanBot) – [Open Source](https://github.com/n1try/telegram-middleman-bot) - Message broker bot to translate HTTP calls into Telegram messages.
+* [@mitupbot](https://t.me/mitupbot?start=src_awesome) – [Open Source](https://gitlab.com/meetupbot/mitup-telegram-bot) bot to organize events and meetups in your groups with RSVPs and timezone-aware reminders, without joining the chat.
 * [@movie_adviser_bot](https://telegram.me/movie_adviser_bot) – Advises best rated movie everyday.
 * [@nosticker_bot](https://t.me/nosticker_bot) – Removes any sticker posted to the group
 * [@OmniGest_bot](https://t.me/OmniGest_bot) – Free all-in-one Telegram group management bot with anti-spam, captcha, AI moderation, custom commands, welcome messages, and a web dashboard.


### PR DESCRIPTION
## Checklist

Before submitting, please confirm:

- [x] I've read the [contributing guidelines](contributing.md)
- [x] My entry follows the exact format: `* [Name](https://url) – Single sentence description.`
  - Uses `–` (en dash), not `-` or `—`
  - Description ends with a period `.`
  - Link is a direct URL (no redirect shorteners)
- [x] I placed the entry in **alphabetical order** within the correct section
- [x] This is a **single entry per PR** (one item only)
- [x] The link is publicly accessible

## Section

Which section does this entry belong to?

- [x] Bots
- [ ] Inline Bots
- [ ] Games
- [ ] Bot Libs (specify language below)
- [ ] Tools
- [ ] Themes
- [ ] Groups
- [ ] Channels
- [ ] Bot Stores
- [ ] Telegram Directory
- [ ] Other: ___________

## About the entry

Mitup is a bot for organizing meetups with your groups. You create a meeting in a private chat with the bot, share one card into the group, and it tracks who is coming, with RSVPs, a waiting list, and reminders in each person's own timezone. The bot never joins the group itself.

Running since 2015, free, no ads, MIT-licensed, translated into six languages by its community. Docs at https://mitup.social, source at https://gitlab.com/meetupbot/mitup-telegram-bot.

Disclosure: I am the maintainer.