### PR TITLE
Add Catallaxy marketplace bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Join our supergroup on Telegram: [![@awesometelegram](https://img.shields.io/bad
 * [@CrawlbenchAlertsBot](https://t.me/CrawlbenchAlertsBot) – Telegram bot that sends Facebook Marketplace match alerts from [Crawlbench](https://crawlbench.com).
 
 * [@YourAriaBot](https://t.me/YourAriaBot) – Premium AI personal assistant with personality. Warm, sharp, and playful. 20 free msgs, 300 Stars/mo (~\$3). Privacy-first (RAM-only conversations).
+* [Catallaxy Telegram bot](https://t.me/catallaxy_bot) – Marketplace for digital goods on the TON blockchain, payable in crypto with no bank card or KYC.
 
 ### Inline Bots
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Join our supergroup on Telegram: [![@awesometelegram](https://img.shields.io/bad
 * [@CrawlbenchAlertsBot](https://t.me/CrawlbenchAlertsBot) – Telegram bot that sends Facebook Marketplace match alerts from [Crawlbench](https://crawlbench.com).
 
 * [@YourAriaBot](https://t.me/YourAriaBot) – Premium AI personal assistant with personality. Warm, sharp, and playful. 20 free msgs, 300 Stars/mo (~\$3). Privacy-first (RAM-only conversations).
-* [Catallaxy Telegram bot](https://t.me/catallaxy_bot) – Marketplace for digital goods on the TON blockchain, payable in crypto with no bank card or KYC.
+* [Catallaxy Telegram Bot](https://t.me/catallaxy_bot) – Telegram marketplace for digital goods on the TON blockchain.
 
 ### Inline Bots
 


### PR DESCRIPTION
**Catallaxy** - On-chain marketplace for digital goods. Centralized storefront over the decentralized Catallaxy network, full RU/EN localization, light/dark themes.

# About
* Sellers can be people or automated agents; each lists its items/SKUs (agents publish them live via /info), buyers purchase and receive results in real time.
* Payments: native GRAM coin or USDT on TON via TON Connect.
* Architecture: a centralized storefront over the decentralized Catallaxy network — sellers and agents self-host and register via onchain heartbeat.
* Bot: https://t.me/catallaxy_bot 
* Site: https://ctlx.cc

# Why include
* Telegram Apps Center approved https://t.me/tapps_bot/center?startapp=app_catallaxy
* Telegram Mini Apps Analytics SDK integrated (live events confirmed on builders.ton.org)
* Full RU + EN localization with native language_code detection
* Light + dark theme via Telegram-provided CSS variables
* Desktop and mobile layouts.
