### PR TITLE
Refresh tgden entry — counts were stale, add free API + MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,7 +348,7 @@ Challenge your friends in MULTIPLAYER mode!
 * [TGboard](https://tgboard.com/en) – Multilingual directory for discovering Telegram channels, groups, bots, Mini Apps, and sticker packs.
 * [TGMania](https://tgmania.com/) – Searchable directory of 70,000+ Telegram channels and groups by category, country and language, with a 0-10 quality score per channel and a free public JSON API.
 * [tgram.io](https://tgram.io/) – Telegram groups list, telegram group chat, telegram chat rooms, telegram groups to join
-* [tgden](https://tgden.com/) – Catalog & search engine for Telegram: 1.29M channels, 283k group chats, 158k bots, stickers and a regional marketplace. Live subscriber stats, full-text search over posts, multilingual. Free, no login. Free REST API and a hosted MCP server for AI agents.
+* [tgden](https://tgden.com/) – Catalog & search engine for Telegram: 1.2M+ channels, 245k+ group chats, 160k+ bots, stickers and a regional marketplace. Live subscriber stats, full-text search over posts, multilingual. Free, no login. Free REST API (no key, CORS-enabled) and a hosted MCP server for AI agents.
 
 ## Community Forums
 

--- a/README.md
+++ b/README.md
@@ -348,7 +348,7 @@ Challenge your friends in MULTIPLAYER mode!
 * [TGboard](https://tgboard.com/en) – Multilingual directory for discovering Telegram channels, groups, bots, Mini Apps, and sticker packs.
 * [TGMania](https://tgmania.com/) – Searchable directory of 70,000+ Telegram channels and groups by category, country and language, with a 0-10 quality score per channel and a free public JSON API.
 * [tgram.io](https://tgram.io/) – Telegram groups list, telegram group chat, telegram chat rooms, telegram groups to join
-* [tgden](https://tgden.com/) – Catalog & search engine for Telegram: 694k channels, 64k group chats, bots, stickers and a regional marketplace. Live subscriber stats, full-text post search, multilingual. Free, no login. Open MCP server for AI agents.
+* [tgden](https://tgden.com/) – Catalog & search engine for Telegram: 1.29M channels, 283k group chats, 158k bots, stickers and a regional marketplace. Live subscriber stats, full-text search over posts, multilingual. Free, no login. Free REST API and a hosted MCP server for AI agents.
 
 ## Community Forums
 


### PR DESCRIPTION
The existing tgden line understates the catalog by roughly 2x on channels and 4x on group chats. Re-read from the live catalog today:

| | listed | actual |
|---|---|---|
| channels | 694k | **1,298,868** |
| group chats | 64k | **282,719** |
| bots | (unlisted) | **157,909** |

Also mentions the free REST API explicitly (`curl 'https://tgden.com/api/catalog?limit=2'`, no key) alongside the MCP server, which is listed on [Glama](https://glama.ai/mcp/servers/JustJuice55/tgden-api).

One-line diff, same position in **Telegram Directory**.