### PR TITLE
Add @dochost_bot to Bots

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ Join our supergroup on Telegram: [![@awesometelegram](https://img.shields.io/bad
 
 * [@YourAriaBot](https://t.me/YourAriaBot) – Premium AI personal assistant with personality. Warm, sharp, and playful. 20 free msgs, 300 Stars/mo (~\$3). Privacy-first (RAM-only conversations).
 
+* [@dochost_bot](https://t.me/dochost_bot) – Forward a Markdown or HTML file, or just paste the text, and get back a public shareable link. Works without an account; `/link` connects a [dochost](https://dochost.io) account to manage the pages later.
+
 ### Inline Bots
 
 In all inline bots, you need to enter @botname, type words and wait for response (~1 second)


### PR DESCRIPTION
Adds [@dochost_bot](https://t.me/dochost_bot) to **Bots**.

Forward a Markdown or HTML file to the bot, or paste the text directly, and it replies with a public shareable link. Useful for getting a document out of a chat and in front of someone who is not in it.

- Works with no account at all
- `/link` optionally connects a [dochost](https://dochost.io) account so the pages can be managed and kept afterwards
- Commands: `/start`, `/link`, `/account`, `/unlink`, `/about`

**Guidelines checklist**
- [x] Searched previous suggestions — no existing dochost entry in this list
- [x] Individual pull request for this one suggestion
- [x] Added to the bottom of the relevant category
- [x] Succinct description
- [x] Useful PR title (not "Update readme.md")
- [x] No trailing whitespace

Disclosure: I built this bot.