### PR TITLE
Add @mynudgebot to Bots

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Join our supergroup on Telegram: [![@awesometelegram](https://img.shields.io/bad
 * [@CrawlbenchAlertsBot](https://t.me/CrawlbenchAlertsBot) – Telegram bot that sends Facebook Marketplace match alerts from [Crawlbench](https://crawlbench.com).
 
 * [@YourAriaBot](https://t.me/YourAriaBot) – Premium AI personal assistant with personality. Warm, sharp, and playful. 20 free msgs, 300 Stars/mo (~\$3). Privacy-first (RAM-only conversations).
+* [@mynudgebot](https://t.me/mynudgebot) – Sends proactive Telegram reminders and a morning briefing for tasks you describe in plain language, in English or Spanish.
 
 ### Inline Bots
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Join our supergroup on Telegram: [![@awesometelegram](https://img.shields.io/bad
 * [@CrawlbenchAlertsBot](https://t.me/CrawlbenchAlertsBot) – Telegram bot that sends Facebook Marketplace match alerts from [Crawlbench](https://crawlbench.com).
 
 * [@YourAriaBot](https://t.me/YourAriaBot) – Premium AI personal assistant with personality. Warm, sharp, and playful. 20 free msgs, 300 Stars/mo (~\$3). Privacy-first (RAM-only conversations).
-* [@mynudgebot](https://t.me/mynudgebot) – Sends proactive Telegram reminders and a morning briefing for tasks you describe in plain language, in English or Spanish.
+* [@mynudgebot](https://t.me/mynudgebot) – Proactive reminders and a morning briefing for tasks you capture by text or voice note, in your own language. More at [inudge.io](https://inudge.io).
 
 ### Inline Bots
 


### PR DESCRIPTION
Adds [@mynudgebot](https://t.me/mynudgebot) to the Bots section.

It's a Telegram-native reminder assistant: you describe what you need to do in
plain language — typed or as a voice note — and it messages you before each item
is due instead of waiting for you to check a list. It replies in the language you
write to it in.

Site: https://inudge.io

Added at the bottom of the Bots section per contributing.md.
