### PR TITLE
Add Aeon (autonomous AI agent) to Bots

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Join our supergroup on Telegram: [![@awesometelegram](https://img.shields.io/bad
 * [@CrawlbenchAlertsBot](https://t.me/CrawlbenchAlertsBot) – Telegram bot that sends Facebook Marketplace match alerts from [Crawlbench](https://crawlbench.com).
 
 * [@YourAriaBot](https://t.me/YourAriaBot) – Premium AI personal assistant with personality. Warm, sharp, and playful. 20 free msgs, 300 Stars/mo (~\$3). Privacy-first (RAM-only conversations).
+* [Aeon](https://github.com/aeonfun/aeon) – [Open Source](https://github.com/aeonfun/aeon) autonomous AI agent framework that reports to Telegram with interactive inline buttons and inbound command routing (webhook and long-polling). Self-hosted, MIT.
 
 ### Inline Bots
 


### PR DESCRIPTION
Adding [Aeon](https://github.com/aeonfun/aeon) to the **Bots** list.

Aeon is an open-source, self-hosted autonomous AI agent framework (MIT). It fits alongside the existing self-hosted AI-agent bots in this section (BotVa, C3Poh, OpenClaw): Telegram is one of its delivery channels, a run reports back to a chat with interactive inline buttons, and inbound commands are routed to the agent from Telegram over both the webhook and long-polling paths.

Repository: https://github.com/aeonfun/aeon

- License: MIT, actively maintained (daily commits)
- Placed at the bottom of the Bots category, single entry, formatting matches the surrounding lines.

Disclosure: I contribute to this project.