### PR TITLE
Add AdminHub to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ Challenge your friends in MULTIPLAYER mode!
  * [Untether](https://github.com/littlebearapps/untether) – Self-hosted bot bridging AI coding agents to Telegram with inline keyboards, voice transcription, real-time streaming, and file transfer.
  * [tgwatch](https://github.com/assinscreedFC/tgwatch) – Zero-infra health monitoring for aiogram bots and Telethon userbots: account health (restricted/banned/dead session), native Telegram alerts, SQLite, no Prometheus/Grafana. Python.
  * [OpenPaw](https://github.com/daxaur/openpaw) – Open-source CLI tool (`npx pawmode`) with a built-in Telegram bridge to chat with Claude from your phone. Includes 38 skills covering email, calendar, Spotify, smart home, GitHub, Slack and more.
+ * [AdminHub](https://adminhub.tools) – No-code platform that turns a Telegram channel into a business: Mini App storefront, paid subscriptions, courses and AI customer support.
 
 ## Themes
 


### PR DESCRIPTION
Adding AdminHub — a no-code platform that turns a Telegram channel into a business (Mini App storefront, paid subscriptions, courses, AI customer support). Disclosure: I'm from the AdminHub team. Happy to adjust placement or wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Formatted per contributing.md: en dash, single-sentence description, added at the bottom of Tools.