### PR TITLE
Add FlowCastle SDK to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ Challenge your friends in MULTIPLAYER mode!
 ## Tools
 
  * [BanOnExit](https://github.com/BotMaven/BanOnExit) – Automatically ban users who join and leave your Telegram groups or channels within a configurable time frame
+ * [FlowCastle SDK](https://github.com/FlowCastle/flowcastle-sdk) – MIT middleware for grammY, Telegraf, aiogram and python-telegram-bot that adds a contact CRM, live chat, broadcasts, and conversion analytics to an existing bot.
  * [Jellyfin Telegram Channel Sync](https://github.com/GeiserX/jellyfin-telegram-channel-sync) – Syncs Jellyfin user access with Telegram channel membership.
  * [Maltego Telegram](https://github.com/vognik/maltego-telegram) – Rich Set of Entities & Transforms for OSINT on Telegram with Maltego
  * [mtproto-manager](https://github.com/vdistortion/mtproto-manager) – A Bash script for managing MTProto proxies on Linux with Docker, FakeTLS, and multi-user support.


### PR DESCRIPTION
Adds [FlowCastle SDK](https://github.com/FlowCastle/flowcastle-sdk) to **Tools** (alphabetical position, entry matches the enforced format with en dash and trailing period).

It is MIT-licensed middleware for the four main bot frameworks (grammY, Telegraf, aiogram, python-telegram-bot) that connects an existing bot to the FlowCastle dashboard: contact CRM, live-chat handoff, broadcasts, and conversion analytics. Privacy filtering runs locally in the bot's process; ordinary updates never wait on the backend. Placed in Tools rather than a language section because it spans two languages and four frameworks (same reasoning as `teleping`).

Disclosure: I am the author (FlowCastle, which is already listed under Bot Development, is my product; the SDK is its open-source integration layer with a free tier).

🤖 Generated with [Claude Code](https://claude.com/claude-code)