### PR TITLE
Add @Blluchatbot to the Bots section

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Join our supergroup on Telegram: [![@awesometelegram](https://img.shields.io/bad
 * [@AnonInboxProBot](https://t.me/AnonInboxProBot) – Anonymous inbox that collects messages sent through a personal link. Free tier, one-time 150 Stars Pro upgrade, Mini App included.
 * [AskePub](https://github.com/GeiserX/AskePub) – Open-source bot that uses GPT-4o to generate AI study notes from ePub books.
 * [@AwakariBit](https://t.me/AwakariBot) – [Open Source](https://github.com/awakari/bot-telegram) bot for reading the real-time search results from various sources.
+* [@Blluchatbot](https://t.me/Blluchatbot) – [Open Source](https://github.com/Moorgan21/bluechat) Anonymous chat bot that connects users randomly or by filters (gender, age, location); includes AI profile moderation and abuse-report judging (Gemini Vision + DeepSeek).
 * [BotVa](https://github.com/cohe4ko/BotVa) – [Open Source](https://github.com/cohe4ko/BotVa) Self-hosted multi-bot Telegram platform powered by Claude AI with MCP integration, persistent memory, and team coordination.
 * [@BroletterBot](https://t.me/BroletterBot) – [Open Source](https://github.com/landigf/Broletter) personalized daily science briefing. Reads arXiv every night, explains papers via Gemini, and delivers a tap-to-expand preview card so you only read what interests you. Built for grad students and researchers. Telegram Stars subscriptions, free 7-day trial.
 * [C3Poh](https://github.com/andyuninvited/c3poh_for_claudecode) – Telegram bridge that lets you DM your Claude Code AI agent from your phone and receive responses.


### PR DESCRIPTION
Re-opening the addition from #244 (that PR's branch was force-pushed to sync with the current alphabetical order, so GitHub wouldn't let it reopen — opening fresh here).

- Bot: https://t.me/Blluchatbot
- Source: https://github.com/Moorgan21/bluechat

Anonymous chat bot that connects users randomly or via filtered search (gender, age, location).

Re the moderation question raised on #244: every profile photo is screened by an AI vision model (Gemini) before it's accepted — it's checked for sexual content, graphic violence, and hate symbols, and rejects on any doubt or error (fail-closed, not fail-open). Separately, any user can report another user's profile (photo/name/bio) or an in-chat conversation; reports go through an AI judge (vision model for profile reports, text model for chat reports) that reviews the actual content. A confirmed violation results in an immediate ban of the offending user (not gated behind a warning count) plus a small reward to the reporter; a baseless report instead gives the reporter a warning, and repeat false reporters get auto-banned, which keeps the report system itself from being abused.